### PR TITLE
IPv4 `AUTO` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support [tnedi.me](https://tnedi.me/json)
 ### Changed
 - `get_private_ipv4` function modified
+- `get_public_ipv4` function modified
 - `_ipsb_ipv4` function modified
 - `_ipapi_ipv4` function modified
 - `_ipinfo_ipv4` function modified

--- a/ipspot/ipv4.py
+++ b/ipspot/ipv4.py
@@ -253,11 +253,11 @@ def get_public_ipv4(api: IPv4API=IPv4API.AUTO, geo: bool=False,
     :param timeout: timeout value for API
     """
     api_map = {
-        IPv4API.IPAPI: _ipapi_ipv4,
-        IPv4API.IPINFO: _ipinfo_ipv4,
-        IPv4API.IPSB: _ipsb_ipv4,
         IPv4API.IDENTME: _ident_me_ipv4,
         IPv4API.TNEDIME: _tnedime_ipv4,
+        IPv4API.IPSB: _ipsb_ipv4,
+        IPv4API.IPAPI: _ipapi_ipv4,
+        IPv4API.IPINFO: _ipinfo_ipv4,
     }
 
     if api == IPv4API.AUTO:


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
- `get_public_ipv4` function modified
#### Any other comments?
I rearranged the order of the `api_map` in the `get_public_ipv4` function to ensure that APIs with specific endpoints for **IPv4** take priority. Since dictionaries in **Python 3.7** and above maintain the order of items, this change should work as intended!
